### PR TITLE
Enable use with webpack 2

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,11 @@
 "use strict";
 
-var ConcatSource = require("webpack-core/lib/ConcatSource");
+var ConcatSource;
+try {
+    ConcatSource = require("webpack-core/lib/ConcatSource");
+} catch(e) {
+    ConcatSource = require("webpack-sources").ConcatSource;
+}
 
 function BannerWebpackPlugin(options) {
     this.options = options || {};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "banner-webpack-plugin",
-  "version": "0.1.3",
+  "version": "0.2.3",
   "description": "append content before or after js bundle",
   "keywords": [
     "front-end",


### PR DESCRIPTION
webpack-core is obsolete in webpack 2, so requiring webpack-sources for ConcatSource if webpack-core fails fixes "cannot find module" error when using webpack 2.